### PR TITLE
Fix birthplace seeder

### DIFF
--- a/database/seeders/BirthPlaceSeeder.php
+++ b/database/seeders/BirthPlaceSeeder.php
@@ -24,6 +24,7 @@ class BirthPlaceSeeder extends Seeder
             $model = BirthPlace::create([
                 'province' => $data[1],
                 'city_or_municipality' => $data[0],
+                'name' => $data[0] . ', ' . $data[1]
             ]);
             // $model->id = $model->newUniqueId();
             // dump($model->getAttributes());


### PR DESCRIPTION
The name field was being left empty. It was supposed to be automatically filled in by an observer.